### PR TITLE
removed leading spaces in combined certificate generation

### DIFF
--- a/templates/default/combined_certs.erb
+++ b/templates/default/combined_certs.erb
@@ -1,4 +1,4 @@
 <%= @domain_cert %>
 <% @chain_certs.each do |cert| %>
-  <%= cert %>
+<%=   cert %>
 <% end %>


### PR DESCRIPTION
nginx does not handle a combined certificate with leading spaces
