### PR TITLE
customizable source data_bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A recipe for setting up system-wide SSL certs on Ubuntu / Debian systems.
 REQUIREMENTS
 ============
 
-Ubuntu or Debian Linux system and an encrypted data bag named "ssl".
+Ubuntu or Debian Linux system and an encrypted data bag named "ssl" (or customized in node['ssl']['data_bag']).
 
 ATTRIBUTES
 ==========
@@ -14,6 +14,8 @@ ATTRIBUTES
     node['ssl']['certs_dir'] = '/etc/ssl/certs'
     node['ssl']['keys_dir']  = '/etc/ssl/keys'
     node['ssl']['group']     = 'ssl-cert'
+    node['ssl']['data_bag']  = 'ssl'
+    node['ssl']['data_bag_query']  = '*:*'
 
 USAGE
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,6 @@ debian_group = "ssl-cert"
 default['ssl']['certs_dir'] = debian_certs
 default['ssl']['keys_dir']  = debian_keys
 default['ssl']['group']     = debian_group
+
+default['ssl']['data_bag']  = 'ssl'
+default['ssl']['data_bag_query']  = '*:*'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,5 @@
-search(:ssl, '*:*') do |s|
-  ssl = Chef::EncryptedDataBagItem.load("ssl", s['id'])
+search(node['ssl']['data_bag'], node['ssl']['data_bag_query']) do |s|
+  ssl = Chef::EncryptedDataBagItem.load(node['ssl']['data_bag'], s['id'])
 
   cert_domain = ssl['id'].gsub('_', '.')
   install_cert(cert_domain, ssl['cert'])


### PR DESCRIPTION
It's necessary to use different data bags for the certificates when in different environments, etc..
This patch allows to customize ssl.data_bag and ssl.data_bag_query in order to get different certs.
